### PR TITLE
[Parka] Add a new way to analyse a Parka Result (The Constraintor)

### DIFF
--- a/parka/src/main/scala/io/univalence/parka/Constraintor.scala
+++ b/parka/src/main/scala/io/univalence/parka/Constraintor.scala
@@ -1,5 +1,14 @@
 package io.univalence.parka
 
+/**
+  * The Constraintor Object is a way to analyse a Parla Result
+  * This is convenient if you use Parka to verify that the new version of your project is working as expected
+  * For example if your new version should not change anything about the data process then the parka result
+  * should be empty. Instead of looking inside the parka result you can just set a constraint about your Parka Result
+  * using the Constraintor.
+  * Example:
+  * Constraintor.respectConstraints(analysis)(isSimilar) should return Pass in case of nothing has changed.
+  */
 object Constraintor {
   sealed trait Status
   case object Pass extends Status
@@ -39,5 +48,4 @@ object Constraintor {
       case false => Fail(verification.map(_._1): _*)
     }
   }
-
 }

--- a/parka/src/main/scala/io/univalence/parka/Constraintor.scala
+++ b/parka/src/main/scala/io/univalence/parka/Constraintor.scala
@@ -1,0 +1,43 @@
+package io.univalence.parka
+
+object Constraintor {
+  sealed trait Status
+  case object Pass extends Status
+  case class Fail(constraints: Constraint*) extends Status
+
+  sealed trait Constraint{
+    def ok(pa: ParkaAnalysis): Boolean
+  }
+
+  case object isSimilar extends Constraint {
+    override def ok(pa: ParkaAnalysis): Boolean =
+      noOuter.ok(pa) && noInner.ok(pa)
+  }
+  case object noOuter extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      pa.result.outer == Outer(Both(DescribeByRow(0, RowBasedMap.empty),DescribeByRow(0, RowBasedMap.empty)))
+  }
+  case object noInner extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      pa.result.inner.countRowNotEqual == 0
+  }
+
+  case class colChange(col: String) extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      pa.result.inner.byColumn.get(col).map(!_.error.equals(Describe.empty)).getOrElse(throw new Exception("Fail"))
+  }
+
+  case class colNotChange(col: String) extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      !colChange(col).ok(pa)
+  }
+
+  def respectConstraints(pa: ParkaAnalysis)(constraints: Constraint*): Status = {
+    val verification = constraints.map(constraint => (constraint, constraint.ok(pa))).filter({case (_, ok) => ok == false})
+    verification.isEmpty match{
+      case true => Pass
+      case false => Fail(verification.map(_._1): _*)
+    }
+  }
+
+}

--- a/parka/src/main/scala/io/univalence/parka/Constraintor.scala
+++ b/parka/src/main/scala/io/univalence/parka/Constraintor.scala
@@ -36,9 +36,19 @@ object Constraintor {
       pa.result.inner.byColumn.get(col).map(!_.error.equals(Describe.empty)).getOrElse(throw new Exception("Fail"))
   }
 
+  case class colsChange(col: String*) extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      col.forall(colChange(_).ok(pa))
+  }
+
   case class colNotChange(col: String) extends Constraint{
     override def ok(pa: ParkaAnalysis): Boolean =
       !colChange(col).ok(pa)
+  }
+
+  case class colsNotChange(col: String*) extends Constraint{
+    override def ok(pa: ParkaAnalysis): Boolean =
+      col.forall(colNotChange(_).ok(pa))
   }
 
   def respectConstraints(pa: ParkaAnalysis)(constraints: Constraint*): Status = {

--- a/parka/src/test/scala/io/univalence/parka/ConstraintorTest.scala
+++ b/parka/src/test/scala/io/univalence/parka/ConstraintorTest.scala
@@ -1,6 +1,6 @@
 package io.univalence.parka
 
-import io.univalence.parka.Constraintor.{Fail, Pass, colChange, colNotChange, isSimilar, noInner, noOuter}
+import io.univalence.parka.Constraintor.{Fail, Pass, colChange, colNotChange, colsChange, colsNotChange, isSimilar, noInner, noOuter}
 import io.univalence.sparktest.SparkTest
 import org.apache.spark.sql.Dataset
 import org.scalatest.FunSuite
@@ -186,5 +186,28 @@ class ConstraintorTest extends FunSuite with SparkTest {
     val analysis            = Parka(left, right)("key");
     assert(Constraintor.respectConstraints(analysis)(colChange("col1")) == Pass)
     assert(Constraintor.respectConstraints(analysis)(colNotChange("col1")) == Fail(List(colNotChange("col1")): _*))
+  }
+
+  test("constraintor should pass the ColsChange and fail the ColsNotChange") {
+    val left: Dataset[Element2] =
+      dataset(
+        Element2("0", 3, 0),
+        Element2("1", 2, 1),
+        Element2("2", 1, 2),
+        Element2("3", 0, 3)
+      )
+    val right: Dataset[Element2] =
+      dataset(
+        Element2("0", 0, 3),
+        Element2("1", 1, 2),
+        Element2("2", 2, 1),
+        Element2("3", 3, 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(colsChange("col1", "col2")) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(colChange("col1"), colChange("col2")) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(colsNotChange("col1", "col2")) == Fail(List(colsNotChange("col1","col2")): _*))
+    assert(Constraintor.respectConstraints(analysis)(colNotChange("col1"), colNotChange("col2")) == Fail(List(colNotChange("col1"), colNotChange("col2")): _*))
   }
 }

--- a/parka/src/test/scala/io/univalence/parka/ConstraintorTest.scala
+++ b/parka/src/test/scala/io/univalence/parka/ConstraintorTest.scala
@@ -1,0 +1,190 @@
+package io.univalence.parka
+
+import io.univalence.parka.Constraintor.{Fail, Pass, colChange, colNotChange, isSimilar, noInner, noOuter}
+import io.univalence.sparktest.SparkTest
+import org.apache.spark.sql.Dataset
+import org.scalatest.FunSuite
+
+import scala.collection.mutable.ArrayBuffer
+
+class ConstraintorTest extends FunSuite with SparkTest {
+  test("constraintor should pass the similar test") {
+    val data: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+
+    val analysis            = Parka(data, data)("key");
+    assert(Constraintor.respectConstraints(analysis)(noInner, noOuter) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(isSimilar) == Pass)
+  }
+
+  test("constraintor should not pass the similar test") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 3),
+        Element("1", 2),
+        Element("2", 1),
+        Element("3", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(isSimilar) == Fail(List(isSimilar): _*))
+  }
+
+  test("constraintor should pass the no outer test") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 3),
+        Element("1", 2),
+        Element("2", 1),
+        Element("3", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(noOuter) == Pass)
+  }
+
+  test("constraintor should not pass the no outer test") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 3),
+        Element("1", 2),
+        Element("2", 1),
+        Element("3", 0),
+        Element("4", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(noOuter) == Fail(List(noOuter): _*))
+  }
+
+  test("constraintor should pass the no inner test") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3),
+        Element("4", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(noInner) == Pass)
+  }
+
+  test("constraintor should not pass the no inner test") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 3),
+        Element("1", 2),
+        Element("2", 1),
+        Element("3", 0),
+        Element("4", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(noInner) == Fail(List(noInner): _*))
+  }
+
+  test("constraintor should fail the ColChange and pass the ColNotChange") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(colNotChange("col1")) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(colChange("col1")) == Fail(List(colChange("col1")): _*))
+  }
+
+  test("constraintor should fail the ColChange and pass the ColNotChange when another column changed") {
+    val left: Dataset[Element2] =
+      dataset(
+        Element2("0", 0, 0),
+        Element2("1", 1, 1),
+        Element2("2", 2, 2),
+        Element2("3", 3, 3)
+      )
+    val right: Dataset[Element2] =
+      dataset(
+        Element2("0", 0, 3),
+        Element2("1", 1, 2),
+        Element2("2", 2, 1),
+        Element2("3", 3, 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(colNotChange("col1")) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(colChange("col1")) == Fail(List(colChange("col1")): _*))
+  }
+
+  test("constraintor should pass the ColChange and fail the ColNotChange") {
+    val left: Dataset[Element] =
+      dataset(
+        Element("0", 0),
+        Element("1", 1),
+        Element("2", 2),
+        Element("3", 3)
+      )
+    val right: Dataset[Element] =
+      dataset(
+        Element("0", 3),
+        Element("1", 2),
+        Element("2", 1),
+        Element("3", 0)
+      )
+
+    val analysis            = Parka(left, right)("key");
+    assert(Constraintor.respectConstraints(analysis)(colChange("col1")) == Pass)
+    assert(Constraintor.respectConstraints(analysis)(colNotChange("col1")) == Fail(List(colNotChange("col1")): _*))
+  }
+}


### PR DESCRIPTION
Parka is a good way to strengthen testing between versions. But the only way until now was to have to look at the Parka Result. Here is a prototype to certify a Parka Result according to some constraints to be respected between the input and output dataset.